### PR TITLE
ADDED: Extended the section on working with tree-shaped data.

### DIFF
--- a/docs/ratt-extract/index.md
+++ b/docs/ratt-extract/index.md
@@ -114,9 +114,9 @@ app.use(
 ### PostgreSQL
 -->
 
-<h3 id='excel'>Extensible Markup Language (XML) files</h3>
+<h3 id='xml'>Extensible Markup Language (XML) sources</h3>
 
-Extensible Markup Language (file name extension `.xml`) is similar to HTML, but where you can define your own tags to use. This is why it is a very useful format  to store, search and share your data.
+Extensible Markup Language (file name extension `.xml`) is similar to HTML, but where you can define your own tags to use. This is why it is a very useful format to store, search and share your data.
 
 RATT has a dedicated connector for XML files.  After such files [are uploaded as TriplyDB Assets](#assets), RATT can connect to them as follows:
 

--- a/docs/ratt-extract/index.md
+++ b/docs/ratt-extract/index.md
@@ -88,13 +88,27 @@ More advanced tabular formats like [Microsoft Excel](#excel) *are* able to store
 <h3 id='shapefile'>ShapeFile (ESRI ArcGIS)</h3>
 -->
 
-<!-- TODO
-### JSON
--->
+<h3 id='json'>JSON sources</h3>
 
-<!-- TODO
-### XML
--->
+JSON (JavaScript Object Notation) is a popular open standard for interchanging tree-shaped data.
+
+The following example uses a JSON source that is stored as a [TriplyDB asset](#asset):
+
+```ts
+const account = 'my-account'
+const dataset = 'my-dataset'
+app.use(
+  mw.fromJson(Ratt.Source.triplyDb.asset(account, dataset, {name: 'my-data.json'})),
+)
+```
+
+The following example uses an in-line specified JSON source:
+
+```ts
+app.use(
+  mw.fromJson([{ a: "a", b: "b", c: "c" }]),
+)
+```
 
 <!-- TODO
 ### PostgreSQL

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -675,84 +675,384 @@ app.use(
 
 Notice that it is almost never useful to store the empty string in linked data.  So the treatment of the empty string as a NULL value is the correct default behavior.
 
-<h2 id='access-nested-data'> Access data</h2>
+## Tree-shaped data
 
-### JSON
-It is often the case that we want to access data that are nested and use them to create linked data. For example, we want to access the types of the properties that a person named J.D. has.
+Tree-shaped data is very common in different source systems.  For example, JSON- and XML-based formats are tree-shaped.  RATT has good support for working with such sources.
+
+We will use the following example in this section:
+
 ```json
 {
-  "name": "J.D.",
-  "properties": [
+  "metadata": {
+    "title": {
+      "name": "Data about countries."
+    }
+  },
+  "data": {
+    "countries": [
+      {
+        "id": "nl",
+        "name": "The Netherlands"
+      },
+      {
+        "id": "de",
+        "name": "Germany"
+      }
+    ]
+  }
+}
+```
+
+Since the RATT record abstracts away the syntactic specifics of the source system format, the above example may be read from a JSON source (see [connecting JSON sources](#json)), or from another kind of source.  For example, the RATT record may be read from the following XML source, assuming the contents of the `<root>` tag are selected:
+
+```xml
+<?xml version="1.0"?>
+<root>
+  <metadata>
+    <title>
+      <value>Data about countries.</value>
+    </title>
+  </metadata>
+  <data>
+    <countries>
+      <id>nl</id>
+      <name>The Netherlands</name>
+    </countries>
+    <countries>
+      <id>de</id>
+      <name>Germany</name>
+    </countries>
+  </data>
+</root>
+```
+
+See [the section on connecting XML sources](#xml) for more information.
+
+### Specifying paths (nested keys)
+
+In tabular data, keys (or column names) are singular.  But in tree-shaped data a *path* of the tree can consist of one or more keys that must be traversed in sequence.
+
+Paths are specified as dot-separated sequences of keys, starting at the top-level and ending at the required value.  For the above example, RATT can access the `"name"` key inside the `"title"` key, which itself is nested inside the `"metadata"` key.  This path is expressed in [1].  Notice that the path expressed in [1] is different from the path expressed in [2], which also access the `"name"` key, but nested inside the `"labels"` and then `"data"` keys.
+
+```
+[1] metadata.title.name
+[2] data.countries.name
+```
+
+Path expressions can be used anywhere singular keys can be used.  For example, we can assert the title of a dataset in the following way:
+
+```ts
+app.use(
+  mw.addQuad(
+    prefix.dataset('my-dataset'),
+    dct.title,
+    mw.toLiteral('metadata.title.value', {language: 'en'})),
+)
+```
+
+This results in the following assertion:
+
+```trig
+dataset:my-dataset dct:title 'Data about countries.'@en.
+```
+
+<h3 id='accessing-lists-by-index'>Accessing lists by index</h3>
+
+Tree-shaped data formats often allow multiple values to be specified in a sequence.  Examples of this are XML tags with the same key that are directly nested under the same parent, and lists in JSON.
+
+RATT is able to access specific elements from such lists based on their *index* or position.  Following the standard practice in Computer Science, RATT refer to the first element in the list as having index 0.  The second element has index 1, etc.
+
+For the above example record, we can assert the first label of the country:
+
+```ts
+app.use(
+  mw.addQuad(
+    mw.toIri('data.countries[0].id', {prefix: prefix.country}),
+    rdfs.label,
+    mw.toLiteral('data.countries[0].name', {language: 'en'})),
+)
+```
+
+This results in the following assertion:
+
+```trig
+country:nl rdfs:label 'The Netherlands'@en.
+```
+
+We can also assert the second label of the same country.  Notice that only the index is different (‘1’ instead of ‘0’):
+
+```ts
+app.use(
+  mw.addQuad(
+    mw.toIri('data.countries[1].id', {prefix: prefix.country}),
+    rdfs.label,
+    mw.toLiteral('data.countries[1].name', {language: 'en'})),
+)
+```
+
+This results in the following assertion:
+
+```trig
+country:de rdfs:label 'Germany'@en.
+```
+
+### Iterating over lists
+
+In the previous section, we saw that we were able to make a first assertion for the first label of the country in the source data.  We were then also able to make a second asstion for the second label of the same country.
+
+But what do we do if there are 100 labels in 100 different languages?  And what do we do if some countries have a label in 2 locales, but other countries have a label in 1 or 3 languaes?  What we need is a simple way to express that we want RATT to make an assertion for each element in the list.
+
+RATT uses the `mw.forEach` function for this purpose.  The following code snippet asserts *each* label for the country in the example data:
+
+```ts
+app.use(
+  mw.forEach('data.countries',
+    mw.addQuad(
+      mw.toIri('id', {prefix: prefix.country}),
+      rdfs.label,
+      mw.toLiteral('name', {language: 'en'}))),
+)
+```
+
+Notice the following details:
+- `mw.forEach` uses the path expression `'data.countries'` to identify the list.
+- Inside the `mw.forEach` function, each element in the list is made available separately.
+- This allows the `'id'` and `'name'` keys to be identified directly.
+
+The above code snippet makes one assertion for every element in the `"countries"` list:
+
+```trig
+country:nl rdfs:label 'The Netherlands'@en-us,
+                      'Nederland'@nl-nl.
+```
+
+The elements that `mw.forEach` iterates over are themselves RATT records.  This implies that all functions that work for full RATT records also work for the RATT records inside `mw.forEach`.
+
+### Special keys when iterating over lists
+
+In the previous section we saw that `mw.forEach` allows us to iterate over the elements in an list.  The elements are themselves made available as RATT records.  The RATT records inside an `mw.forEach `function are smaller.  This allow the regular keys of the iterated-over elements to be accessed directly.
+
+In addition to these regular keys, RATT records inside `mw.forEach` also contain additional keys that simplify common operations.  The following subsections explain the following special keys:
+
+- [Index key (`$index`)](#index-key)
+- [Parent key (`$parent`)](#parent-key)
+- [Root key (`$root`)](#root-key)
+
+<h4 id='index-key'>Index key (`$index`)</h4>
+
+Each RATT record that is made available in `mw.forEach` contains the `$index` key.  The value of this key is the index of the element in the list.  This is the same index that is used to access specific elements in an list, as explained in [the section on accessing lists by index](#accessing-lists-by-index).
+
+The index key is often useful for assigning a unique subject IRI to every element.
+
+Suppose we have the following source data.  We do not want to use the values of the `"name"` key for our subject IRI, because these names contain spaces and possibly other problematic characters that make the IRI more difficult to read and use.
+
+```json
+{
+  "countries": [
     {
-      "type": "Apartment",
-      "country":"Netherlands"
+      "name": "The Netherlands"
     },
     {
-      "type": "Cottage",
-      "country":"Italy"
-    }
+      "name": "Germany"
+    },
+    {
+      "name": "Italy"
+    },
+    …
   ]
 }
 ```
 
-Thus, we would want to access each value of ```type``` key in the array of ```properties ``` . For this reason, we should use the below middleware:
+The following code snippet uses the `$index` key that is made available inside `mw.forEach` in order to create a unique subject IRI for each country:
 
-```sh
-mw.forEach(
-'properties',
-{more middlewares}
+```ts
+app.use(
+  mw.forEach('countries',
+    mw.addQuad(
+      mw.toIri('$index', {prefix: prefix.country}),
+      rdfs.label,
+      mw.toLiteral('name', {language: 'en'}))),
 )
 ```
 
-Inside this middleware, each value of each type in the array can be accessed directly by using ```'type[0]'``` or ```'type[1]'```. In order to access a key through the parent node, ```'$parent.'``` has to be used in the beginning from of the path. Lastly, if you have to access a key through the start of the Json, ```'$root.'``` has to be used in the beginning of the path.
-You can see the structure of the record inside  ```forEach()``` using ```logRecord()```:
+This results in the following assertions:
 
-```sh
-mw.forEach(
-'properties',
-mw.logRecord()
+```trig
+country:0 rdfs:label 'The Netherlands'@en.
+country:1 rdfs:label 'Germany'@en.
+country:2 rdfs:label 'Italy'@en.
+```
+
+<h4 id='parent-key'>Parent key (`$parent`)</h4>
+
+When `mw.forEach` iterates through a list of elements, it makes the enclosing *parent* record available under key `$parent`.
+
+The parent record is the record that directly contains the path that was specified in the first argument to the `mw.forEach` call.
+
+For example, the parent record in the following call is the record that directly contains the `"data"` key:
+
+```ts
+app.use(
+  mw.forEach('data.countries',
+    …
 )
 ```
-The printed result is:
 
+The `$parent` key can be observed when `mw.logRecord` is used to print the iterated-over elements to the terminal:
+
+```ts
+app.use(
+  mw.forEach('data.countries',
+    mw.logRecord()),
+)
 ```
+
+For our example source data, this emits the following 2 RATT records:
+
+```json
 {
-  "type": "Apartment",
-  "country": "Netherlands",
+  "id": "en",
+  "name": "The Netherlands",
   "$index": 0,
   "$parent": {
-    "name": "J.D.",
-    "properties": [
-      {
-        "type": "Apartment",
-        "country": "Netherlands"
-      },
-      {
-        "type": "Cottage",
-        "country": "Italy"
-      }
-    ]
-  },
-  "$root": "__circular__"
-}
-{
-  "type": "Cottage",
-  "country": "Italy",
-  "$index": 1,
-  "$parent": {
-    "name": "J.D.",
-    "properties": [
-      {
-        "type": "Apartment",
-        "country": "Netherlands"
-      },
-      {
-        "type": "Cottage",
-        "country": "Italy"
-      }
-    ]
+    "data": {
+      "labels": [
+        {
+          "id": "en",
+          "name": "The Netherlands",
+        },
+        {
+          "id": "de"
+          "name": "Germany",
+        }
+      ]
+    }
   },
   "$root": "__circular__"
 }
 ```
 
+and:
+
+```json
+{
+  "id": "de",
+  "name": "Germany",
+  "$index": 1,
+  "$parent": {
+    "data": {
+      "labels": [
+        {
+          "id": "en",
+          "name": "The Netherlands",
+        },
+        {
+          "id": "de"
+          "name": "Germany",
+        }
+      ]
+    }
+  },
+  "$root": "__circular__"
+}
+```
+
+The `$root` key is explained in [the next section](#root-key).
+
+<h4 id='root-key'>Root key (`$root`)</h4>
+
+Sometimes it may be necessary to access a part of the original RATT record that is outside of the scope of the `mw.forEach` call.
+
+Every RATT record inside an` mw.forEach` call contains the `"$root"` key.  The value of the root key provides a link to the full RATT record.  Because the `$root` key is part of the linked-to RATT record, it is not possible to print the value of the root key.  (This would result in infinite output.)  For this reason, the value of the `$root` key is printed as the special value `"__circular__"`.
+
+For the above examples, the parent record and root record are the same, but this is not always the case.  Specifically, the parent record and root record are different when `mw.forEach` calls are nested.
+
+The following data contains an inner list (key `"labels"`) inside an outer list (`"countries"`):
+
+```json
+{
+  "data": {
+    "countries": [
+      {
+        "id": "NL",
+        "labels": [
+          {
+            "name": "The Netherlands",
+            "locale": "en-us"
+          },
+          {
+            "name": "Nederland",
+            "locale": "nl-nl"
+          }
+        ]
+      },
+      {
+        "id": "EN",
+        "labels": [
+          {
+            "name": "England",
+            "locale": "en-gb"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The following nested `mw.forEach` call shows the difference between the `"$parent"` key and the `$root` key.  The `$parent` key allows then the individual country objects to be accessed, while the `"$root"` key allows the entire tree to be accessed:
+
+```ts
+app.use(
+  mw.forEach('data.countries',
+    mw.forEach('labels',
+      mw.logRecord())),
+)
+```
+
+The following RATT record is printed first (3 records are printed in total).  Notice that the value of the outer `$parent` and `"$root"` keys are now different:
+- The `$parent` key allows access to the first country.
+- The `$root` key allows access to the full record (describing multiple countries).
+
+```json
+{
+  "name": "The Netherlands",
+  "locale": "en-us",
+  "$index": 0,
+  "$parent": {
+    "id": "NL",
+    "labels": [
+      {
+        "name": "The Netherlands",
+        "locale": "en-us"
+      },
+      {
+        "name": "Nederland",
+        "locale": "nl-nl"
+      }
+    ],
+    "$index": 0,
+    "$parent": {
+      "data": {
+        "countries": [
+          {
+            "id": "NL",
+            "labels": "__circular__"
+          },
+          {
+            "id": "EN",
+            "labels": [
+              {
+                "name": "England",
+                "locale": "en-gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "$root": "__circular__"
+  },
+  "$root": "__circular__"
+}
+```

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -728,7 +728,7 @@ The principles that are documented in this section can be applied to any form of
 
 In tabular data, keys (or column names) are singular.  But in tree-shaped data a *path* of the tree can consist of one or more keys that must be traversed in sequence.
 
-Paths are specified as dot-separated sequences of keys, starting at the top-level and ending at the required value.  For the JSON example in the previous section, RATT can access the `"name"` key inside the `"title"` key, which itself is nested inside the `"metadata"` key.  This path is expressed in [1].  Notice that the path expressed in [1] is different from the path expressed in [2], which also access the `"name"` key, but nested inside the `"countries"` and then `"data"` keys.  (The use of the `[0]` index is explained in the next section.)
+Paths are specified as dot-separated sequences of keys, starting at the top-level and ending at the required value.  For the JSON example in the previous section, RATT can access the `"name"` key inside the `"title"` key, which itself is nested inside the `"metadata"` key.  This path is expressed in [1].  Notice that the path expressed in [1] is different from the path expressed in [2], which also accesses the `"name"` key, but nested inside the `"countries"` and then `"data"` keys.  (The use of the `[0]` index is explained in the next section.)
 
 ```
 [1] metadata.title.name
@@ -794,7 +794,7 @@ country:de rdfs:label 'Germany'@en.
 
 <h3 id='list-object'>Iterating over lists of objects</h3>
 
-In the previous section, we saw that we were able to assert the name of the first country and the name of the second country.  But what do we do if we want to assert the name for every country in the world?  And what do we do if some countries have a name in 2 languages, but other countries have a name in 1 or 3 languaes?  What we need is a simple way to express that we want RATT to make an assertion for every element in a list.
+In the previous section, we saw that we were able to assert the name of the first country and the name of the second country.  But what do we do if we want to assert the name for every country in the world?  And what do we do if some countries have a name in 2 languages, but other countries have a name in 1 or 3 languages?  What we need is a simple way to express that we want RATT to make an assertion for every element in a list.
 
 RATT uses the `mw.forEach` function for this purpose.  The following code snippet asserts the name for *each* country in the example data:
 
@@ -1057,7 +1057,7 @@ The following RATT record is printed first (3 records are printed in total).  No
 
 In [the previous section](#list-object) we showed how to iterate over lists of objects.  But what happens if a list does not contain objects but elements of primitive type?  Examples include lists of strings or lists of numbers.
 
-Function `mw.forEach` does not work with lists containing primitive types, because it assumes a RATT record structure which can only be provided by objects.  Lucklily, RATT includes the functions `mw.toIri.forEach` and `mw.toLiteral.forEach` that can be specifically used to iterate over lists of primitives.
+Function `mw.forEach` does not work with lists containing primitive types, because it assumes a RATT record structure which can only be provided by objects.  Luckily, RATT includes the functions `mw.toIri.forEach` and `mw.toLiteral.forEach` that can be specifically used to iterate over lists of primitives.
 
 ```ts
   app.use(

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -732,7 +732,7 @@ See [the section on connecting XML sources](#xml) for more information.
 
 In tabular data, keys (or column names) are singular.  But in tree-shaped data a *path* of the tree can consist of one or more keys that must be traversed in sequence.
 
-Paths are specified as dot-separated sequences of keys, starting at the top-level and ending at the required value.  For the above example, RATT can access the `"name"` key inside the `"title"` key, which itself is nested inside the `"metadata"` key.  This path is expressed in [1].  Notice that the path expressed in [1] is different from the path expressed in [2], which also access the `"name"` key, but nested inside the `"labels"` and then `"data"` keys.
+Paths are specified as dot-separated sequences of keys, starting at the top-level and ending at the required value.  For the above example, RATT can access the `"name"` key inside the `"title"` key, which itself is nested inside the `"metadata"` key.  This path is expressed in [1].  Notice that the path expressed in [1] is different from the path expressed in [2], which also access the `"name"` key, but nested inside the `"countries"` and then `"data"` keys.
 
 ```
 [1] metadata.title.name

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -726,7 +726,7 @@ Since the RATT record abstracts away the syntactic specifics of the source syste
 </root>
 ```
 
-See [the section on connecting XML sources](#xml) for more information.
+See [the section on connecting XML sources](/docs/ratt-extract#xml) for more information.
 
 ### Specifying paths (nested keys)
 

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -798,7 +798,7 @@ country:de rdfs:label 'Germany'@en.
 
 ### Iterating over lists
 
-In the previous section, we saw that we were able to make a first assertion for the first label of the country in the source data.  We were then also able to make a second asstion for the second label of the same country.
+In the previous section, we saw that we were able to make a first assertion for the first label of the country in the source data.  We were then also able to make a second assertion for the second label of the same country.
 
 But what do we do if there are 100 labels in 100 different languages?  And what do we do if some countries have a label in 2 locales, but other countries have a label in 1 or 3 languaes?  What we need is a simple way to express that we want RATT to make an assertion for each element in the list.
 

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -703,7 +703,7 @@ We will use the following example in this section:
 }
 ```
 
-Since the RATT record abstracts away the syntactic specifics of the source system format, the above example may be read from a JSON source (see [connecting JSON sources](#json)), or from another kind of source.  For example, the RATT record may be read from the following XML source, assuming the contents of the `<root>` tag are selected:
+Since the RATT record abstracts away the syntactic specifics of the source system format, the above example may be read from a JSON source (see [connecting JSON sources](/docs/ratt-extract#json)), or from another kind of source.  For example, the RATT record may be read from the following XML source, assuming the contents of the `<root>` tag are selected:
 
 ```xml
 <?xml version="1.0"?>

--- a/docs/ratt-transform/index.md
+++ b/docs/ratt-transform/index.md
@@ -739,7 +739,7 @@ Paths are specified as dot-separated sequences of keys, starting at the top-leve
 [2] data.countries.name
 ```
 
-Path expressions can be used anywhere singular keys can be used.  For example, we can assert the title of a dataset in the following way:
+Path expressions can be used anywhere with singular keys.  For example, we can assert the title of a dataset in the following way:
 
 ```ts
 app.use(

--- a/docs/triplydb-js/index.md
+++ b/docs/triplydb-js/index.md
@@ -827,7 +827,7 @@ TODO
 
 ##### See also
 
-The meaning of the argument to this method are identifical to those of the [`Account.addDataset(name: string, metadata?: object)`](#accountadddatasetname-string-metadata-object) method.
+The meaning of the argument to this method are identical to those of the [`Account.addDataset(name: string, metadata?: object)`](#accountadddatasetname-string-metadata-object) method.
 
 #### Account.getDataset(name: string)
 
@@ -1178,7 +1178,7 @@ The service type is specified with the `type` parameter.  It supports the follow
 
 <dl>
   <dt><code>'sparql'</code></dt>
-  <dd>Starts a SPARQL service. A SPARQL 1.1 compliant service is very scalable and performance, but without advanced reasoning capabilities.</dd> 
+  <dd>Starts a SPARQL service. A SPARQL 1.1 compliant service is very scalable and performance, but without advanced reasoning capabilities.</dd>
   <dt><code>'sparql-jena'</code></dt>
   <dd>Starts a SPARQL JENA service. A SPARQL 1.1 compliant service that is less scalable and less performant, but allows reasoning (RDFS or OWL) to be enabled.</dd>
   <dt><code>'elasticsearch'</code></dt>


### PR DESCRIPTION
- Added example data.
- Clarified that the source format is abstracted away from (XML/JSON/other).
- Explained how list elements can be accessed by index.
- Explained how list elements can be iterated over.
- Explained the special meaning of `$index`, `$parent`, and `$root`.
- Added an example where `$parent` != `$root`.
- Explained special value `"__circular"`.