### PR TITLE
ADDED: A section on how to send 'raw' SPARQL requests.

### DIFF
--- a/docs/triply-api/index.md
+++ b/docs/triply-api/index.md
@@ -205,11 +205,11 @@ Everybody who has access to the dataset also has access to its services, includi
 - For *Internal* datasets, only users that are logged into the triple store can issue queries.
 - For *Private* datasets, only users that are logged into the triple store and are members of `ACCOUNT` can issue queries.
 
-Notice that for professional use it is easier and better to use [saved queries](#saved-queries).  Saved queries have peristent URIs, descriptive metadata, versioning, and support for reliable large-scale pagination.  Still, if you do not have a saved query at your disposal and want to perform a custom SPARQL request against an accessible endpoint, you can still do so.  TriplyDB implements the SPARQL 1.1 Query Protocol standard for this purpose.
+Notice that for professional use it is easier and better to use [saved queries](#saved-queries).  Saved queries have persistent URIs, descriptive metadata, versioning, and support for reliable large-scale pagination.  Still, if you do not have a saved query at your disposal and want to perform a custom SPARQL request against an accessible endpoint, you can do so.  TriplyDB implements the SPARQL 1.1 Query Protocol standard for this purpose.
 
 #### Sending a SPARQL Query request
 
-According to the SPARQL 1.1 Protocol, queries can be send in the 3 different ways that are displayed in <a href='#table-http-sparql-query'>Table 1</a>.  For small query strings it is possible to send an HTTP GET request (row 1 in <a href='#table-http-sparql-query'>Table 1</a>).  A benefit of this approach is that all information is stored in one URI.  For public data, copy/pasting this URI in a web browser runs the query.  For larger query strings it is required to send an HTTP POST request (rows 2 and 3 in <a href='#table-http-sparql-query'>Table 1</a>).  The reason for this is that longer query strings result in longer URIs when following the HTTP GET approach.  Some applications do not support longer URIs, or they even silently truncate them resulting in an error down the line.  The direct POST approach (row 3 in <a href='#table-http-sparql-query'>Table 1</a>) is the best of these 3 variants, since it most clearly communicates that it is senting a SPARQL query request (see the `Content-Type` column).
+According to the SPARQL 1.1 Protocol, queries can be send in the 3 different ways that are displayed in <a href='#table-http-sparql-query'>Table 1</a>.  For small query strings it is possible to send an HTTP GET request (row 1 in <a href='#table-http-sparql-query'>Table 1</a>).  A benefit of this approach is that all information is stored in one URI.  For public data, copy/pasting this URI in a web browser runs the query.  For larger query strings it is required to send an HTTP POST request (rows 2 and 3 in <a href='#table-http-sparql-query'>Table 1</a>).  The reason for this is that longer query strings result in longer URIs when following the HTTP GET approach.  Some applications do not support longer URIs, or they even silently truncate them resulting in an error down the line.  The direct POST approach (row 3 in <a href='#table-http-sparql-query'>Table 1</a>) is the best of these 3 variants, since it most clearly communicates that it is sending a SPARQL query request (see the `Content-Type` column).
 
 <figure id='table-http-sparql-query'>
   <table>
@@ -249,9 +249,9 @@ According to the SPARQL 1.1 Protocol, queries can be send in the 3 different way
   <figcaption>Table 1 - Overview of the three different ways in which SPARQL queries can be issues over HTTP.</figcaption>
 </figure>
 
-#### SPAQL Query result formats
+#### SPARQL Query result formats
 
-SPARQL services are able to return results in different formats.  The user can specify the preferred format by specifying the corresponding Media Type in the HTTP `Accept` header.  TriplyDB supported the following Media Types.  Notice that the chosen result format must be supported for your query form.
+SPARQL services are able to return results in different formats.  The user can specify the preferred format by specifying the corresponding Media Type in the HTTP `Accept` header.  TriplyDB supports the following Media Types.  Notice that the chosen result format must be supported for your query form.
 
 | Result format | Media Type                        | Query forms         |
 | ------------- | --------------------------------- | ------------------- |
@@ -262,7 +262,7 @@ SPARQL services are able to return results in different formats.  The user can s
 | N-Triples     | `application/n-triples`           | CONSTRUCT, DESCRIBE |
 | RDF/XML       | `application/rdf+xml`             | CONSTRUCT, DESCRIBE |
 | SPARQL JSON   | `application/sparql-results+json` | ASK, SELECT         |
-| SPARQL XML    | `application/saprql-results+xml`  | ASK, SELECT         |
+| SPARQL XML    | `application/sparql-results+xml`  | ASK, SELECT         |
 | TriG          | `application/trig`                | CONSTRUCT, DESCRIBE |
 | TSV           | `text/tab-separated-values`       | SELECT              |
 | Turtle        | `text/turtle`                     | CONSTRUCT, DESCRIBE |

--- a/docs/triply-api/index.md
+++ b/docs/triply-api/index.md
@@ -190,9 +190,358 @@ over the Pokémon dataset:
 https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql
 ```
 
-### Sparql
+### SPARQL
 
-### Jena
+There are two service types in TriplyDB that expose the SPARQL 1.1 Query Language: "Sparql" and "Jena".  The former works well for large quantities of instance data with a relatively small data model; the latter works well for smaller quantities of data with a richer data model.
+
+SPARQL services expose a generic endpoint URI at the following location (where `ACCOUNT`, `DATASET` and `SERVICE` are user-chosen names):
+
+```none
+https://api.triplydb.com/datasets/ACCOUNT/DATASET/services/SERVICE/sparql
+```
+
+Everybody who has access to the dataset also has access to its services, including its SPARQL services:
+- For *Public* datasets, everybody on the Internet or Intranet can issue queries.
+- For *Internal* datasets, only users that are logged into the triple store can issue queries.
+- For *Private* datasets, only users that are logged into the triple store and are members of `ACCOUNT` can issue queries.
+
+Notice that for professional use it is easier and better to use [saved queries](#saved-queries).  Saved queries have peristent URIs, descriptive metadata, versioning, and support for reliable large-scale pagination.  Still, if you do not have a saved query at your disposal and want to perform a custom SPARQL request against an accessible endpoint, you can still do so.  TriplyDB implements the SPARQL 1.1 Query Protocol standard for this purpose.
+
+#### Sending a SPARQL Query request
+
+According to the SPARQL 1.1 Protocol, queries can be send in the 3 different ways that are displayed in <a href='#table-http-sparql-query'>Table 1</a>.  For small query strings it is possible to send an HTTP GET request (row 1 in <a href='#table-http-sparql-query'>Table 1</a>).  A benefit of this approach is that all information is stored in one URI.  For public data, copy/pasting this URI in a web browser runs the query.  For larger query strings it is required to send an HTTP POST request (rows 2 and 3 in <a href='#table-http-sparql-query'>Table 1</a>).  The reason for this is that longer query strings result in longer URIs when following the HTTP GET approach.  Some applications do not support longer URIs, or they even silently truncate them resulting in an error down the line.  The direct POST approach (row 3 in <a href='#table-http-sparql-query'>Table 1</a>) is the best of these 3 variants, since it most clearly communicates that it is senting a SPARQL query request (see the `Content-Type` column).
+
+<figure id='table-http-sparql-query'>
+  <table>
+    <thead>
+      <tr>
+        <th></th>
+        <th>HTTP Method</th>
+        <th>Query String Parameters</th>
+        <th>Request <code>Content-Type</code></th>
+        <th>Request Message Body</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>query via GET</th>
+        <td>GET</td>
+        <td><code>query</code> (exactly 1)<br><code>default-graph-uri</code> (0 or more)<br><code>named-graph-uri</code> (0 or more)</td>
+        <td>none</td>
+        <td>none</td>
+      </tr>
+      <tr>
+        <th>query via URL-encoded POST</th>
+        <td>POST</td>
+        <td>none</td>
+        <td><code>application/x-www-form-urlencoded</code></td>
+        <td>URL-encoded, ampersand-separated query parameters.<br><code>query</code> (exactly 1)<br><code>default-graph-uri</code> (0 or more)<br><code>named-graph-uri</code> (0 or more)</td>
+      </tr>
+      <tr>
+        <th>query via POST directly</th>
+        <td>POST</td>
+        <td><code>default-graph-uri</code> (0 or more)<br><code>named-graph-uri</code> (0 or more)</td>
+        <td><code>application/sparql-query</code></td>
+        <td>Unencoded SPARQL query string</td>
+      </tr>
+    </tbody>
+  </table>
+  <figcaption>Table 1 - Overview of the three different ways in which SPARQL queries can be issues over HTTP.</figcaption>
+</figure>
+
+#### SPAQL Query result formats
+
+SPARQL services are able to return results in different formats.  The user can specify the preferred format by specifying the corresponding Media Type in the HTTP `Accept` header.  TriplyDB supported the following Media Types.  Notice that the chosen result format must be supported for your query form.
+
+| Result format | Media Type                        | Query forms         |
+| ------------- | --------------------------------- | ------------------- |
+| CSV           | `text/csv`                        | SELECT              |
+| JSON          | `application/json`                | ASK, SELECT         |
+| JSON-LD       | `application/ld+json`             | CONSTRUCT, DESCRIBE |
+| N-Quads       | `application/n-quads`             | CONSTRUCT, DESCRIBE |
+| N-Triples     | `application/n-triples`           | CONSTRUCT, DESCRIBE |
+| RDF/XML       | `application/rdf+xml`             | CONSTRUCT, DESCRIBE |
+| SPARQL JSON   | `application/sparql-results+json` | ASK, SELECT         |
+| SPARQL XML    | `application/saprql-results+xml`  | ASK, SELECT         |
+| TriG          | `application/trig`                | CONSTRUCT, DESCRIBE |
+| TSV           | `text/tab-separated-values`       | SELECT              |
+| Turtle        | `text/turtle`                     | CONSTRUCT, DESCRIBE |
+
+#### Examples of SPARQL Query requests
+
+This section contains examples of SPARQL HTTP requests.  The requests run either of the following two SPARQL queries against a public SPARQL endpoint that contains data about Pokemon:
+
+```sparql
+select * { ?s ?p ?o. } limit 1
+```
+
+```sparql
+construct where { ?s ?p ?o. } limit 1
+```
+
+The examples made use of the popular command-line tool [cURL](https://curl.se).  These examples should also work in any other HTTP client tool or library.
+
+#### GET request
+
+```sh
+curl https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql?query=select%20%2A%20%7B%20%3Fs%20%3Fp%20%3Fo.%20%7D%20limit%201
+```
+
+Result:
+
+```json
+[
+  {
+    "s": "https://triplydb.com/academy/pokemon/vocab/",
+    "p": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    "o": "http://www.w3.org/2002/07/owl#Ontology"
+  }
+]
+```
+
+#### URL-encoded POST request
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data query=select%20%2A%20%7B%20%3Fs%20%3Fp%20%3Fo.%20%7D%20limit%201
+```
+
+Result:
+
+```json
+[
+  {
+    "s": "https://triplydb.com/academy/pokemon/vocab/",
+    "p": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    "o": "http://www.w3.org/2002/07/owl#Ontology"
+  }
+]
+```
+
+#### Direct POST request
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'select * { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```json
+[
+  {
+    "s": "https://triplydb.com/academy/pokemon/vocab/",
+    "p": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    "o": "http://www.w3.org/2002/07/owl#Ontology"
+  }
+]
+```
+
+#### SPARQL JSON
+
+Like the previous example, but with an `Accept` header that specifies Media Type `application/sparql-results+json`:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: application/sparql-results+json' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'select * { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```json
+{
+  "head": {
+    "vars": ["s", "p", "o"]
+  },
+  "results": {
+    "bindings": [
+      {
+        "s": {
+          "type": "uri",
+          "value": "https://triplydb.com/academy/pokemon/vocab/"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#Ontology"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### SPARQL XML
+
+Like the previous example, but with Media Type `application/sparql-results+xml` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: application/sparql-results+xml' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'select * { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```xml
+<sparql xmlns="http://www.w3.org/2005/sparql-results#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+  <head>
+    <variable name="s"/>
+    <variable name="p"/>
+    <variable name="o"/>
+  </head>
+  <results distinct="false" ordered="true">
+    <result>
+      <binding name="s">
+        <uri>https://triplydb.com/academy/pokemon/vocab/</uri>
+      </binding>
+      <binding name="p">
+        <uri>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</uri>
+      </binding>
+      <binding name="o">
+        <uri>http://www.w3.org/2002/07/owl#Ontology</uri>
+      </binding>
+    </result>
+  </results>
+</sparql>
+```
+
+#### SPARQL tab-separated values
+
+Like the previous examples, but with Media Type `text/tab-separated-values` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: text/tab-separated-values' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'select * { ?s ?p ?o } limit 1'
+```
+
+```none
+"s"	"p"	"o"
+"https://triplydb.com/academy/pokemon/vocab/"	"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"	"http://www.w3.org/2002/07/owl#Ontology"
+```
+
+#### SPARQL comma-separated values
+
+Like the previous examples, but with Media Type `text/csv` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: text/csv' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'select * { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```none
+"s","p","o"
+"https://triplydb.com/academy/pokemon/vocab/","http://www.w3.org/1999/02/22-rdf-syntax-ns#type","http://www.w3.org/2002/07/owl#Ontology"
+```
+
+#### JSON-LD
+
+Like the previous examples, but with a SPARQL construct query and Media Type `application/ld+json` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: application/ld+json' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'construct where { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```json
+{ "@graph": [
+    { "@id": "https://triplydb.com/academy/pokemon/vocab/",
+      "@type": "http://www.w3.org/2002/07/owl#Ontology" }
+] }
+```
+
+#### N-Quads
+
+Like the previous examples, but with Media Type `application/n-quads` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: application/n-quads' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'construct where { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```json
+{ "@graph": [
+    { "@id": "https://triplydb.com/academy/pokemon/vocab/",
+      "@type": "http://www.w3.org/2002/07/owl#Ontology" }
+] }
+```
+
+#### N-Triples
+
+Like the previous examples, but with Media Type `application/n-triples` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: application/n-triples' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'construct where { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```turtle
+<https://triplydb.com/academy/pokemon/vocab/>	<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>	<http://www.w3.org/2002/07/owl#Ontology> .
+```
+
+#### TriG
+
+Like the previous examples, but with Media Type `application/trig` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: application/trig' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'construct where { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```turtle
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:	<http://www.w3.org/2002/07/owl#> .
+<https://triplydb.com/academy/pokemon/vocab/>	rdf:type	owl:Ontology .
+```
+
+#### Turtle
+
+Like the previous examples, but with Media Type `text/turtle` in the `Accept` header:
+
+```sh
+curl -X POST https://api.triplydb.com/datasets/academy/pokemon/services/pokemon/sparql \
+  -H 'Accept: text/turtle' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'construct where { ?s ?p ?o } limit 1'
+```
+
+Result:
+
+```turtle
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:	<http://www.w3.org/2002/07/owl#> .
+<https://triplydb.com/academy/pokemon/vocab/>	rdf:type	owl:Ontology .
+```
 
 ### Elastic
 
@@ -204,7 +553,7 @@ returned entities.
 The text search API is only available for a dataset after an
 ElasticSearch service has been created for that dataset.
 
-Two types of searches can be performed: a simple search, and a custom 
+Two types of searches can be performed: a simple search, and a custom
 search. Simple searches require one search term for a fuzzy match. Custom
 searches accept a JSON object conforming to [the elasticsearch query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
 


### PR DESCRIPTION
This started with me wanting to document JSON-LD.  Turns out that this
works similar to many other formats, so I documented all of them in one go.

- This replaces the empty "Sparql" and "Jena" headers.

- This indicates that there are 2 service types that support
SPARQL ("Sparql" and "Jena").

- Explains who can send queries to Public/Internal/Private endpoints.

- Indicates that Saved Queries are better for professional
use.  (Maybe this should like to the pagination documentation by
Thomas de Groot?)

- Documents the 3 ways in which SPARQL Query requests can be sent with
HTTP (+table).

- Documents the N formats that can be requested (+table).

- Includes N examples with cURL.