### PR TITLE
IMPLEMENT: Document the output types of addQuery

### DIFF
--- a/docs/triplydb-js/index.md
+++ b/docs/triplydb-js/index.md
@@ -599,7 +599,7 @@ The `metadata` argument specifies the required Dataset or Service and access lev
       <dt><code>"private"</code></dt>
       <dd>The query can only be accessed by the <a href='#account'><code>Account</code></a> object for which it is created.</dd>
       <dt><code>"internal"</code></dt>
-      <dd>The query can only be accessed by people who are logged into the TriplyDB instance (denoted by the value of environment variable <code>TRIPLYDB_URL</code>).
+      <dd>The query can only be accessed by people who are logged into the TriplyDB instance (denoted by the value of environment variable <code>TRIPLYDB_URL</code>).</dd>
       <dt><code>"public"</code></dt>
       <dd>The query can be accessed by everybody.</dd>
     </dl>
@@ -612,7 +612,36 @@ The `metadata` argument specifies the required Dataset or Service and access lev
   <dd>The human-readable name of the query.  This name may include spaces and other characters that are not allowed in the URL-friendly <code>name</code>.</dd>
 
   <dt><code>output: string</code></dt>
-  <dd>The visualization plugin that is used to display the result set.  If none is set it defaults to <code>"table"</code>.  Other options may include: <code>"response"</code>, <code>"geo"</code>, <code>"gallery"</code>, <code>"markup"</code>, etc</dd>
+  <dd>The visualization plugin that is used to display the result set of the query. If none is set it defaults to <code>"table"</code>.
+    <dl>
+      <dt><code>"boolean"</code></dt>
+      <dd>The [boolean](https://triply.cc/docs/yasgui#table) view is a special view for ask queries. The value is either "true" or "false", and is visualized as  <code>`X`</code>(False) or <code>`V`</code>(True).</dd>
+      <dt><code>"gallery"</code></dt>
+      <dd>The [gallery](https://triply.cc/docs/yasgui#gallery) view allows SPARQL results to be displayed in an HTML gallery.</dd>
+      <dt><code>"gchart"</code></dt>
+      <dd>The [gchart](https://triply.cc/docs/yasgui#charts) renders geographical, temporal and numerical data in interactive charts such as bar-, line- and pie charts.</dd>
+      <dt><code>"geo"</code></dt>
+      <dd>The [geo](https://triply.cc/docs/yasgui#geo) allows SPARQL results that contain GeoSPARQL semantics to be automatically interpreted and displayed on a 2D map.</dd>
+      <dt><code>"geoEvents"</code></dt>
+      <dd>The [geoEvents](https://triply.cc/docs/yasgui#geoEvents) plugin renders geographical events as a story map.</dd>
+      <dt><code>"geo3d"</code></dt>
+      <dd>The [geo3d](https://triply.cc/docs/yasgui#geo3d) allows SPARQL results that contain GeoSPARQL semantics to be automatically interpreted and displayed on a 3D globe.</dd>
+      <dt><code>"markup"</code></dt>
+      <dd>The [markup](https://triply.cc/docs/yasgui#markup) can be used to render a variety of markup languages. This requires the use of the `?markup` variable to identify which variable to render.</dd>
+      <dt><code>"network"</code></dt>
+      <dd>The [network](https://triply.cc/docs/yasgui#network) renders SPARQL Construct results in a graph representation. The maximum amount of results that can be visualized is 1.000 due to performance.</dd>
+      <dt><code>"pivot"</code></dt>
+      <dd>The [pivot](https://triply.cc/docs/yasgui#pivot) view renders SPARQL results in an interactive pivot table where you are able to aggregate the results by dragging your binding variables to columns or rows.</dd>
+      <dt><code>"response"</code></dt>
+      <dd>The [response](https://triply.cc/docs/yasgui#response) view shows the body of the response and offers a easy way to download the result as a file.</dd>
+      <dt><code>"table"</code></dt>
+      <dd>The [table](https://triply.cc/docs/yasgui#table) view allows SPARQL results to be displayed in a table. Each
+      column in the table corresponds to a variable that belongs to the
+      outer projection.</dd>
+      <dt><code>"timeline"</code></dt>
+      <dd>The [timeline](https://triply.cc/docs/yasgui#timeline) timeline renders the SPARQL results on a Timeline. </dd>
+    </dl>
+  </dd>
 
   <dt><code>variables: Variable[]</code></dt>
   <dd>
@@ -2872,15 +2901,15 @@ To reliably retrieve a large number of results as the output of a `construct` or
    }
    ```
 
-   5b. Save the results to a file. 
-   
+   5b. Save the results to a file.
+
    For saving SPARQL `construct` queries:
 
    ```ts
    // Saving the results of a SPARQL construct query to a file.
    await results.toFile("my-file.nt");
    ```
-   
+
    For saving SPARQL `select` queries. Currently we only support saving the file to a .tsv format:
 
    ```ts


### PR DESCRIPTION
 Added output types for add Query. All the output types have been linked to the visualizations in the data.